### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ ArHelper::Sugar
 
 ArHelper::Sugar adds some convenient abstraction methods to ActionView and
 ActionController, that makes querying a bit more pleasing and grammatically 
-correct (IMO). This looks beatiful with Dr Nic's map_by_method gem
+correct (IMO). This looks beautiful with Dr Nic's map_by_method gem
 for example instead of User.find(:all).map_by_name, you can do all(:users).map_by_name
 
 all :name_of_model, options={}


### PR DESCRIPTION
@vanntastic, I've corrected a typographical error in the documentation of the [ar_helper](https://github.com/vanntastic/ar_helper) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
